### PR TITLE
Add support for category tabs in 3D view's tool shelf.

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -286,6 +286,7 @@ class MMDToolsObjectPanel(bpy.types.Panel):
     bl_label = 'MMD Tools'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
+    bl_category = 'MMD'
     bl_context = ''
 
     def draw(self, context):
@@ -398,6 +399,7 @@ class MMDToolsRiggingPanel(bpy.types.Panel):
     bl_label = 'MMD Rig Tools'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
+    bl_category = 'MMD'
     bl_context = ''
 
 


### PR DESCRIPTION
Recently in the trunk, the tool shelf in the 3D view got category tabs.  To specify which category the addon belongs to, this patch defines bl_category='MMD' in the panel UI classes.  I think adding a new category is not recommended, but the mmd_tools have too many features to belong to an existing category.
