### PR TITLE
PMX importer: Support 2.71 and fix texture file path issues

### DIFF
--- a/mmd_tools/import_pmx.py
+++ b/mmd_tools/import_pmx.py
@@ -139,10 +139,10 @@ class PMXImporter:
 
         self.__textureTable = []
         for i in pmxModel.textures:
-            name = os.path.basename(i.path).split('.')[0]
+            name = os.path.basename(i.path.replace('\\', os.path.sep)).split('.')[0]
             tex = bpy.data.textures.new(name=name, type='IMAGE')
             try:
-                tex.image = bpy.data.images.load(filepath=i.path)
+                tex.image = bpy.data.images.load(filepath=bpy.path.resolve_ncase(path=i.path))
             except Exception:
                 logging.warning('failed to load %s', str(i.path))
             self.__textureTable.append(tex)


### PR DESCRIPTION
1) 7573f34

In Blender's master repo, I've added new material property "use_cast_shadows":

https://developer.blender.org/rBfc28732ba65a57bccd47940249999809c2c93eb0

It can be used to simulate MMD material's "drop shadow" property.

2) 6324e7c

This fixes texture file path issues on Linux and OSX.
