### PR TITLE
Improve speed of importing rigid bodies

### DIFF
--- a/mmd_tools/import_pmx.py
+++ b/mmd_tools/import_pmx.py
@@ -613,6 +613,7 @@ class PMXImporter:
 
     def __importJoints(self):
         if self.__onlyCollisions:
+            self.__createNonCollisionConstraint()
             return
         self.__jointTable = []
         for joint in self.__model.joints:


### PR DESCRIPTION
1)  Simple change (a862baa)

Remove local variable 'renameLRBones'.

2) Improve speed of importing rigid bodies (0746c17)

Because the creation of ncc objects are similar,
I found it's faster by duplicating objects instead of creating them individually.

3) Fix bug (f6d442e)

Fix a small bug in my previous commit (0746c17)
