### PR TITLE
Fixed Tail location issue

### DIFF
--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -259,6 +259,13 @@ class __PmxExporter:
                     #if not pmx_bone.displayConnection: #I think this wasn't working properly
                         #pmx_bone.displayConnection = bone.tail - bone.head
 
+                #add fixed and local axes
+                if mmd_bone.enabled_fixed_axis:
+                    pmx_bone.axis = mmd_bone.fixed_axis
+
+                if mmd_bone.enabled_local_axes:
+                    pmx_bone.localCoordinate = pmx.Coordinate(
+                        mmd_bone.local_axis_x, mmd_bone.local_axis_z)
 
             for idx, i in enumerate(pmx_bones):
                 if i.parent is not None:

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -248,19 +248,22 @@ class __PmxExporter:
 
                 if p_bone.mmd_bone.is_tip:
                     pmx_bone.displayConnection = -1
+                elif p_bone.mmd_bone.use_tail_location:
+                    tail_loc = world_mat * mathutils.Vector(bone.tail) * self.__scale * self.TO_PMX_MATRIX
+                    pmx_bone.displayConnection = tail_loc - pmx_bone.location
                 else:
                     for child in bone.children:
                         if child.use_connect:
                             pmx_bone.displayConnection = child
                             break
-                    if not pmx_bone.displayConnection:
-                        pmx_bone.displayConnection = bone.tail - bone.head
+                    #if not pmx_bone.displayConnection: #I think this wasn't working properly
+                        #pmx_bone.displayConnection = bone.tail - bone.head
 
 
-            for i in pmx_bones:
+            for idx, i in enumerate(pmx_bones):
                 if i.parent is not None:
                     i.parent = pmx_bones.index(boneMap[i.parent])
-                    logging.debug('the parent of %s: %s', i.name, i.parent)
+                    logging.debug('the parent of %s:%s: %s', idx, i.name, i.parent)
                 if isinstance(i.displayConnection, pmx.Bone):
                     i.displayConnection = pmx_bones.index(i.displayConnection)
                 elif isinstance(i.displayConnection, bpy.types.EditBone):

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -271,6 +271,10 @@ class PMXImporter:
                 b_bone.mmd_bone.local_axis_x = p_bone.localCoordinate.x_axis
                 b_bone.mmd_bone.local_axis_z = p_bone.localCoordinate.z_axis
 
+            if p_bone.axis is not None:
+                b_bone.mmd_bone.enabled_fixed_axis = True
+                b_bone.mmd_bone.fixed_axis=p_bone.axis
+
             if b_bone.mmd_bone.is_tip:
                 b_bone.lock_rotation = [True, True, True]
                 b_bone.lock_location = [True, True, True]

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -240,7 +240,12 @@ class PMXImporter:
             b_bone.mmd_bone.transform_order = p_bone.transform_order
             b_bone.mmd_bone.is_visible = p_bone.visible
             b_bone.mmd_bone.is_controllable = p_bone.isControllable
-            b_bone.mmd_bone.is_tip = (p_bone.displayConnection == -1)
+
+            if isinstance(p_bone.displayConnection, int):
+                b_bone.mmd_bone.is_tip = (p_bone.displayConnection == -1)
+            else:
+                b_bone.mmd_bone.use_tail_location = True
+
             b_bone.bone.hide = b_bone.mmd_bone.is_tip or not p_bone.visible
 
             if not p_bone.isRotatable:

--- a/mmd_tools/properties/bone.py
+++ b/mmd_tools/properties/bone.py
@@ -67,6 +67,11 @@ class MMDBone(PropertyGroup):
         default=False,
         )
 
+    use_tail_location = BoolProperty(
+        name='Use Tail Location',
+        default=False,
+        )
+
     enabled_local_axes = BoolProperty(
         name='Use Local Axes',
         default=False,

--- a/mmd_tools/properties/bone.py
+++ b/mmd_tools/properties/bone.py
@@ -72,6 +72,17 @@ class MMDBone(PropertyGroup):
         default=False,
         )
 
+    enabled_fixed_axis = BoolProperty(
+        name='Use Fixed Axis',
+        default=False,
+        )
+
+    fixed_axis = FloatVectorProperty(
+        name='Fixed Axis',
+        size=3,
+        default=[0, 0, 0],
+        )
+
     enabled_local_axes = BoolProperty(
         name='Use Local Axes',
         default=False,


### PR DESCRIPTION
When the connection of a bone was a float3 it wasn't exported.
Added a property in bone to indicate if use the tail location for the
connection or not.

I created the commit in a feature branch because this time I made some important changes on the core, and called it pre-release since I think we will be able to release it very soon.

Known Issues:
- Not all bone relationships are exported correctly
- Local axis and axis constraints are not exported (I'm currently working on a fix)

Update: I observed that the relationships don't export correctly when there is more than one bone pointing to the same child with the <code>displayConnection</code> index