### PR TITLE
Point people to maintained version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 mmd_tools
 ===========
 
+# Notice: This version is no longer maintained.  Maintained version: https://github.com/powroupi/blender_mmd_tools
+
 概要
 ----
 mmd_toolsはblender用MMD(MikuMikuDance)モデルデータ(.pmd, .pmx)およびモーションデータ(.vmd)インポータです。


### PR DESCRIPTION
Because powroupi/blender_mmd_tools was forked from this repo, it does not show up in GitHub searches, even though it is the more up-to-date version.  This points people to the up-to-date version.

Ping @sugiany 