### PR TITLE
fixed an error of importing vmd

### DIFF
--- a/mmd_tools/auto_scene_setup.py
+++ b/mmd_tools/auto_scene_setup.py
@@ -8,11 +8,11 @@ def setupFrameRanges():
         ts, te = i.frame_range
         s = min(s, ts)
         e = max(e, te)
-    bpy.context.scene.frame_start = s
-    bpy.context.scene.frame_end = e
+    bpy.context.scene.frame_start = int(s)
+    bpy.context.scene.frame_end = int(e)
     if bpy.context.scene.rigidbody_world is not None:
-        bpy.context.scene.rigidbody_world.point_cache.frame_start = s
-        bpy.context.scene.rigidbody_world.point_cache.frame_end = e
+        bpy.context.scene.rigidbody_world.point_cache.frame_start = int(s)
+        bpy.context.scene.rigidbody_world.point_cache.frame_end = int(e)
 
 def setupLighting():
     bpy.context.scene.world.light_settings.use_ambient_occlusion = True


### PR DESCRIPTION
Probably a python version of the problem that blender uses, the max/min function outputs floating-point numbers and assigns them to frame_ Start/frame_ End, these variables need to receive integers, so there was an error that caused the VMD import to fail.